### PR TITLE
Bump build and add test to check names

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/include/backward.hpp  # [not win]
-    - test -f ${PREFIX}/lib/backward/BackwardConfig.cmake  # [not win]
+    - test -f ${PREFIX}/lib64/backward/BackwardConfig.cmake  # [not win]
     - if not exist %PREFIX%\\Library\\include\\backward.hpp exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\backward\\BackwardConfig.cmake exit 1  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -24,6 +24,12 @@ requirements:
     - elfutils  # [linux]
 
 test:
+  commands:
+    - test -f ${PREFIX}/include/backward.hpp  # [not win]
+    - test -f ${PREFIX}/lib/backward/BackwardConfig.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\backward.hpp exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\backward\\BackwardConfig.cmake exit 1  # [win]
+
   requires:
     - cmake
     - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,12 +24,6 @@ requirements:
     - elfutils  # [linux]
 
 test:
-  commands:
-    - test -f ${PREFIX}/include/backward.hpp  # [not win]
-    - test -f ${PREFIX}/lib64/backward/BackwardConfig.cmake  # [not win]
-    - if not exist %PREFIX%\\Library\\include\\backward.hpp exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\backward\\BackwardConfig.cmake exit 1  # [win]
-
   requires:
     - cmake
     - {{ compiler('c') }}

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,7 +2,7 @@
 
 # Check files
 test -f ${PREFIX}/include/backward.hpp
-test -f ${PREFIX}/lib64/backward/BackwardConfig.cmake
+test -f ${PREFIX}/lib/backward/BackwardConfig.cmake
 
 # Test example build
 mkdir build

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Check files
+test -f ${PREFIX}/include/backward.hpp
+test -f ${PREFIX}/lib64/backward/BackwardConfig.cmake
+
+# Test example build
 mkdir build
 cd build
 cmake $RECIPE_DIR -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
Fix https://github.com/conda-forge/backward-cpp-feedstock/issues/18 . The actual problem of `lib`/`lib64` was already solved in https://github.com/conda-forge/backward-cpp-feedstock/pull/16, but the package was not regenerated as the build numberwas not bumped.

I also added some test on the file paths to avoid regressions.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
